### PR TITLE
Use updated method name to add subscription to dispatcher

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = class Panikk extends Plugin {
       label: "Panikk",
       render: Settings,
     });
-    dispatcher.subscribe("STREAM_START", async () => {
+    dispatcher.addSubscription("STREAM_START", async () => {
       if (!this.settings.get("panikkOnLive", false)) {
         return;
       }
@@ -21,7 +21,7 @@ module.exports = class Panikk extends Plugin {
       await powercord.shutdown();
       suppress = false;
     });
-    dispatcher.subscribe("STREAM_STOP", async () => {
+    dispatcher.addSubscription("STREAM_STOP", async () => {
       if (!this.settings.get("panikkOnLive", false)) {
         return;
       }


### PR DESCRIPTION
Discord seems to have changed the name of the needed method on the dispatcher module from `subscribe` to `addSubscription`. Updating the method name allows Panikk to be loaded and thus work as intended when F5 is pressed, since it doesn't error out when attempting to add the subscription.

That said, Panikk on Live doesn't appear to be functional. The aforementioned subscription's event, whatever it may be, doesn't appear to ever trigger, even when I share my screen. I haven't figured out how to get that working. Perhaps the event name also needs to be changed? I'm not sure how to find that.