### PR TITLE
i think this is how pr works

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,16 +57,20 @@ module.exports = class Panikk extends Plugin {
         suppress = false;
     }
     async addHandlers() {
-        for (let i = 0; i < this.handlers.listeners.length; i++)
+        for (let i = 0; i < this.handlers.listeners.length; i++) {
             document.body.addEventListener(this.handlers.listeners[i][0], this.handlers.listeners[i][1]);
-        for (let i = 0; i < this.handlers.subscriptions.length; i++)
+        }
+        for (let i = 0; i < this.handlers.subscriptions.length; i++) {
             Dispatcher.subscribe(this.handlers.subscriptions[i][0], this.handlers.subscriptions[i][1]);
+        }
     }
     async removeHandlers() {
-        for (let i = 0; i < this.handlers.listeners.length; i++)
+        for (let i = 0; i < this.handlers.listeners.length; i++) {
             document.body.removeEventListener(this.handlers.listeners[i][0], this.handlers.listeners[i][1]);
-        for (let i = 0; i < this.handlers.subscriptions.length; i++)
+        }
+        for (let i = 0; i < this.handlers.subscriptions.length; i++) {
             Dispatcher.unsubscribe(this.handlers.subscriptions[i][0], this.handlers.subscriptions[i][1]);
+        }
     }
 };
 };

--- a/index.js
+++ b/index.js
@@ -1,47 +1,33 @@
 /* eslint-disable quotes */
 const { Plugin } = require("powercord/entities");
-const webpack = require("powercord/webpack");
-const { inject, uninject } = require("powercord/injector");
+const { FluxDispatcher: Dispatcher } = require('powercord/webpack');
 let suppress = false;
 const Settings = require("./components/settings");
 
 module.exports = class Panikk extends Plugin {
   async startPlugin() {
-    const dispatcher = webpack.getModule(["dispatch"], false);
     powercord.api.settings.registerSettings(this.entityID, {
       category: this.entityID,
       label: "Panikk",
       render: Settings,
     });
-    dispatcher.addSubscription("STREAM_START", async () => {
-      if (!this.settings.get("panikkOnLive", false)) {
-        return;
-      }
-      suppress = true;
-      await powercord.shutdown();
-      suppress = false;
-    });
-    dispatcher.addSubscription("STREAM_STOP", async () => {
-      if (!this.settings.get("panikkOnLive", false)) {
-        return;
-      }
-      suppress = true;
-      await powercord.startup();
-      suppress = false;
-    });
-    document.body.removeEventListener("keyup", (e) => this.keyup(e, this));
-    document.body.addEventListener("keyup", (e) => this.keyup(e, this));
+    this.handlers = {
+        listeners: [['keyup', this.keyup.bind(this)]],
+        subscriptions: [
+            ['STREAM_START', this.streamStart.bind(this)],
+            ['STREAM_STOP', this.streamStop.bind(this)],
+        ],
+    };
+    this.addHandlers();
   }
 
   pluginWillUnload() {
-    if (!suppress) {
-      document.body.removeEventListener("keyup", this.keyup);
-    }
+    if (!suppress) this.removeHandlers();
     powercord.api.settings.unregisterSettings(this.entityID);
   }
 
-  async keyup(event, _this) {
-    var key = _this.settings.get("keybind", "F5");
+  async keyup(event) {
+    var key = this.settings.get("keybind", "F5");
     if (event.key === key) {
       if (powercord?.api?.settings?.ready === true) {
         suppress = true;
@@ -49,9 +35,38 @@ module.exports = class Panikk extends Plugin {
         suppress = false;
       } else {
         suppress = true;
-        await powercord.startup();
+        await this.startup();
         suppress = false;
       }
     }
   }
+    async startup() {
+        this.removeHandlers();
+        await powercord.startup();
+    }
+    async streamStart() {
+        if (!this.settings.get('panikkOnLive', false)) return;
+        suppress = true;
+        await powercord.shutdown();
+        suppress = false;
+    }
+    async streamStop() {
+        if (!this.settings.get('panikkOnLive', false)) return;
+        suppress = true;
+        await this.startup();
+        suppress = false;
+    }
+    async addHandlers() {
+        for (let i = 0; i < this.handlers.listeners.length; i++)
+            document.body.addEventListener(this.handlers.listeners[i][0], this.handlers.listeners[i][1]);
+        for (let i = 0; i < this.handlers.subscriptions.length; i++)
+            Dispatcher.subscribe(this.handlers.subscriptions[i][0], this.handlers.subscriptions[i][1]);
+    }
+    async removeHandlers() {
+        for (let i = 0; i < this.handlers.listeners.length; i++)
+            document.body.removeEventListener(this.handlers.listeners[i][0], this.handlers.listeners[i][1]);
+        for (let i = 0; i < this.handlers.subscriptions.length; i++)
+            Dispatcher.unsubscribe(this.handlers.subscriptions[i][0], this.handlers.subscriptions[i][1]);
+    }
+};
 };

--- a/index.js
+++ b/index.js
@@ -1,33 +1,35 @@
 /* eslint-disable quotes */
-const { Plugin } = require("powercord/entities");
+const { Plugin } = require('powercord/entities');
 const { FluxDispatcher: Dispatcher } = require('powercord/webpack');
 let suppress = false;
-const Settings = require("./components/settings");
+const Settings = require('./components/settings');
 
 module.exports = class Panikk extends Plugin {
   async startPlugin() {
     powercord.api.settings.registerSettings(this.entityID, {
       category: this.entityID,
-      label: "Panikk",
+      label: 'Panikk',
       render: Settings,
     });
     this.handlers = {
-        listeners: [['keyup', this.keyup.bind(this)]],
-        subscriptions: [
-            ['STREAM_START', this.streamStart.bind(this)],
-            ['STREAM_STOP', this.streamStop.bind(this)],
-        ],
+      listeners: [['keyup', this.keyup.bind(this)]],
+      subscriptions: [
+        ['STREAM_START', this.streamStart.bind(this)],
+        ['STREAM_STOP', this.streamStop.bind(this)],
+      ],
     };
     this.addHandlers();
   }
 
   pluginWillUnload() {
-    if (!suppress) this.removeHandlers();
+    if (!suppress) {
+      this.removeHandlers();
+    }
     powercord.api.settings.unregisterSettings(this.entityID);
   }
 
   async keyup(event) {
-    var key = this.settings.get("keybind", "F5");
+    const key = this.settings.get('keybind', 'F5');
     if (event.key === key) {
       if (powercord?.api?.settings?.ready === true) {
         suppress = true;
@@ -40,37 +42,40 @@ module.exports = class Panikk extends Plugin {
       }
     }
   }
-    async startup() {
-        this.removeHandlers();
-        await powercord.startup();
+  async startup() {
+    this.removeHandlers();
+    await powercord.startup();
+  }
+  async streamStart() {
+    if (!this.settings.get('panikkOnLive', false)) {
+      return;
     }
-    async streamStart() {
-        if (!this.settings.get('panikkOnLive', false)) return;
-        suppress = true;
-        await powercord.shutdown();
-        suppress = false;
+    suppress = true;
+    await powercord.shutdown();
+    suppress = false;
+  }
+  async streamStop() {
+    if (!this.settings.get('panikkOnLive', false)) {
+      return;
     }
-    async streamStop() {
-        if (!this.settings.get('panikkOnLive', false)) return;
-        suppress = true;
-        await this.startup();
-        suppress = false;
+    suppress = true;
+    await this.startup();
+    suppress = false;
+  }
+  async addHandlers() {
+    for (let i = 0; i < this.handlers.listeners.length; i++) {
+      document.body.addEventListener(this.handlers.listeners[i][0], this.handlers.listeners[i][1]);
     }
-    async addHandlers() {
-        for (let i = 0; i < this.handlers.listeners.length; i++) {
-            document.body.addEventListener(this.handlers.listeners[i][0], this.handlers.listeners[i][1]);
-        }
-        for (let i = 0; i < this.handlers.subscriptions.length; i++) {
-            Dispatcher.subscribe(this.handlers.subscriptions[i][0], this.handlers.subscriptions[i][1]);
-        }
+    for (let i = 0; i < this.handlers.subscriptions.length; i++) {
+      Dispatcher.subscribe(this.handlers.subscriptions[i][0], this.handlers.subscriptions[i][1]);
     }
-    async removeHandlers() {
-        for (let i = 0; i < this.handlers.listeners.length; i++) {
-            document.body.removeEventListener(this.handlers.listeners[i][0], this.handlers.listeners[i][1]);
-        }
-        for (let i = 0; i < this.handlers.subscriptions.length; i++) {
-            Dispatcher.unsubscribe(this.handlers.subscriptions[i][0], this.handlers.subscriptions[i][1]);
-        }
+  }
+  async removeHandlers() {
+    for (let i = 0; i < this.handlers.listeners.length; i++) {
+      document.body.removeEventListener(this.handlers.listeners[i][0], this.handlers.listeners[i][1]);
     }
-};
+    for (let i = 0; i < this.handlers.subscriptions.length; i++) {
+      Dispatcher.unsubscribe(this.handlers.subscriptions[i][0], this.handlers.subscriptions[i][1]);
+    }
+  }
 };


### PR DESCRIPTION
fix: made all handlers work properly 
added methods for uhhhh the stream_start and stuff and remove handlers work, and properly facilitated shutdown so that the plugin doesn't stack listeners when it shouldn't and also fixed the stream_start. two missing features exist. 1) if you panikk and unpanikk and then panikk again during a stream, it will turn on when you stop streaming, and i imagine the end user would not want it to turn itself on if they intentionally turned off powercord while streaming. 2) panikk happens when you set the keybind. i don't have a fix for that yet, though